### PR TITLE
new line delimiter for text input filter

### DIFF
--- a/src/app/components/parts/samples-text/samples-text.component.ts
+++ b/src/app/components/parts/samples-text/samples-text.component.ts
@@ -33,7 +33,7 @@ export class SamplesTextComponent implements OnInit {
     this.loadingSamplesFilter=true;
     if(samples.length >= 1 && samples[0] !== ""){
       if(this.multiple){
-        this.txtSamplesChanged.next(samples.split(','));
+        this.txtSamplesChanged.next(samples.split(/[\n,]+/));
       }else{
         this.txtSamplesChanged.next([samples]);
       }


### PR DESCRIPTION
#Description
On 'Clinical Filtering' page where users want to filter sample IDs with text filter it should be able to copy paste from text with new line delimiter 